### PR TITLE
Add the automatic `has`/`is of` synonymous forms to the generated LF.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Added the automatic `has`/`is of` synonymous forms to the generated LF.
+
 v0.0.26
 
 * Added more information to README file.

--- a/sbvr-libs.ometajs
+++ b/sbvr-libs.ometajs
@@ -17,7 +17,7 @@ SBVRLibs.ApplyFirstExisting = function(rules, ruleArgs) {
 			if(ruleArgs.length > 0) {
 				return this._applyWithArgs.apply(this, [rules[i]].concat(ruleArgs));
 			}
-			return this._apply(rules[i], ruleArgs);
+			return this._apply(rules[i]);
 		}
 	}
 };
@@ -68,7 +68,7 @@ SBVRLibs.AddFactType = function(factType, realFactType) {
 			mappedFactType[i][3] = i;
 			continue;
 		}
-		// Otherwise we have to map based upon matching indentifiers + instance numbers
+		// Otherwise we have to map based upon matching identifiers + instance numbers
 		var mappingFound = false;
 		for(var j = 0; j < factType.length; j++) {
 			var factTypePart = factType[j];
@@ -89,17 +89,6 @@ SBVRLibs.AddFactType = function(factType, realFactType) {
 		}
 	}
 	this._traverseFactType(factType, mappedFactType);
-	if(factType.length === 3 && (factType[1][1] === 'has' || factType[1][1] === 'is of')) {
-		mappedFactType = _.clone(mappedFactType);
-		mappedFactType[0] = mappedFactType[0].slice(0, 3).concat(2);
-		mappedFactType[2] = mappedFactType[2].slice(0, 3).concat(0);
-		if(factType[1][1] === 'has') {
-			this._traverseFactType([factType[2], ['Verb', 'is of', factType[1][2]], factType[0]], mappedFactType);
-		}
-		else if(factType[1][1] === 'is of') {
-			this._traverseFactType([factType[2], ['Verb', 'has', factType[1][2]], factType[0]], mappedFactType);
-		}
-	}
 };
 
 SBVRLibs._traverseFactType = function(factType, create) {

--- a/sbvr-parser.ometajs
+++ b/sbvr-parser.ometajs
@@ -76,7 +76,7 @@ export ometa SBVRParser <: SBVRLibs {
 			Real
 		|	Integer
 		|	Text,
-	
+
 	toSBVREOL =
 		spaces
 		<	(	spaces
@@ -109,7 +109,7 @@ export ometa SBVRParser <: SBVRLibs {
 		-> function() {
 			return $elf._AddIdentifier(identifierType, identifier, baseSynonym)
 		},
-	
+
 	InformalIdentifier =
 		Identifier(undefined, true),
 	Identifier :factTypeSoFar :noAutoComplete =
@@ -144,7 +144,7 @@ export ometa SBVRParser <: SBVRLibs {
 		|	seq(quote)
 		)
 		-> identifier,
-	
+
 	FindIdentifierNest :identifierType :factTypeSoFar :identifierSoFar =
 		IdentifierPart:part
 		(	?identifierSoFar
@@ -159,7 +159,7 @@ export ometa SBVRParser <: SBVRLibs {
 			):vocabulary
 			IsFactTypeIdentifier([identifierType, identifierSoFar, vocabulary], factTypeSoFar)
 		),
-	
+
 	FindVocabulary :identifier =
 		spaces
 		'('?:bracket
@@ -169,7 +169,7 @@ export ometa SBVRParser <: SBVRLibs {
 		|	seq(')')
 		)
 		-> vocabulary,
-	
+
 	FindVocabularyNest :vocabularySoFar =
 		IdentifierPart:part
 		(	?vocabularySoFar
@@ -189,8 +189,8 @@ export ometa SBVRParser <: SBVRLibs {
 			|	'-'
 			)+
 		>,
-	
-	
+
+
 	addVerb =
 		ClearSuggestions Verb(true),
 	Verb :factTypeSoFar =
@@ -228,10 +228,10 @@ export ometa SBVRParser <: SBVRLibs {
 		spaces
 		~Identifier
 		IdentifierPart,
-	
+
 	JoiningQuantifier =
 		matchForAll('Keyword',["and","at","most"]),
-	
+
 	// Be very careful with anywhere you use quantifier as any in-place modifications of the array will be remembered in memoisation.
 	Quantifier =
 		(	Keyword("each")
@@ -258,7 +258,7 @@ export ometa SBVRParser <: SBVRLibs {
 		(	?(noToken===true) seq(word)
 		|	?(noToken!==true) token(word)
 		),
-	
+
 	addThat =
 		Keyword("that"),
 	addThe =
@@ -349,7 +349,7 @@ export ometa SBVRParser <: SBVRLibs {
 		),
 
 	Modifier =
-		"It" "is" 
+		"It" "is"
 		(	"obligatory"
 			-> ['ObligationFormulation']
 		|	"necessary"
@@ -467,7 +467,20 @@ export ometa SBVRParser <: SBVRLibs {
 		)?
 		-> function() {
 			$elf.AddFactType(factType, factType);
-			return ['FactType'].concat(factType).concat([['Attributes']]);
+			var attributes = ['Attributes'];
+			if(factType.length === 3 && (factType[1][1] === 'has' || factType[1][1] === 'is of')) {
+				synFactType = _.cloneDeep(factType);
+				synFactType.reverse()
+				if(synFactType[1][1] === 'has') {
+					synFactType[1][1] = 'is of'
+				}
+				else {
+					synFactType[1][1] = 'has'
+				}
+				$elf.AddFactType(synFactType, factType);
+				attributes.push(['SynonymousForm', synFactType])
+			}
+			return ['FactType'].concat(factType).concat([attributes]);
 		},
 
 	StartVocabulary =
@@ -623,7 +636,7 @@ export ometa SBVRParser <: SBVRLibs {
 	NewComment =
 		StartComment
 		toEOL,
-	
+
 	EOLTerminator =
 		Terminator?
 		spaces
@@ -782,7 +795,7 @@ SBVRParser.IsFactType = function(factType) {
 	return currentLevel.__valid;
 };
 
-var removeRegex = new RegExp('^(?:' + 
+var removeRegex = new RegExp('^(?:' +
 								[	['Term',''].toString(),
 									['Name',''].toString(),
 									['Verb',''].toString()
@@ -962,7 +975,7 @@ SBVRParser.reset = function() {
 	this.ruleVarsCount = 0;
 	this.lines = ['Model'];
 	this.disableCommas = false;
-	
+
 	// Process the built-in vocabulary,
 	// making use of reusing memoisations,
 	// and returning this.inputHead to the way it was found.
@@ -1017,7 +1030,7 @@ SBVRParser.matchForAny = function(rule, arr) {
 	origInput = this.input,
 	ref = {},
 	result = ref;
-	
+
 	for (var idx = 0; idx < arr.length; idx++) {
 		try {
 			self.input = origInput;

--- a/test/sbvr-helper.coffee
+++ b/test/sbvr-helper.coffee
@@ -30,9 +30,20 @@ exports.numberedTerms = (term, amount) ->
 		return numberedTerm
 exports.verb = (verb, negated = false) -> ['Verb', verb, negated]
 exports.factType = factType = (factType...) ->
+	factTypeLF = factTypeBody(factType)
+	attributes = ['Attributes']
+	if factTypeLF.length is 3 and factTypeLF[1][1] in ['has', 'is of']
+		synFormLF = _.cloneDeep(factTypeLF)
+		synFormLF.reverse()
+		synFormLF[1][1] =
+			if synFormLF[1][1] is 'has'
+				'is of'
+			else
+				'has'
+		attributes.push(['SynonymousForm', synFormLF])
 	[	'FactType'
-		factTypeBody(factType)...
-		['Attributes']
+		factTypeLF...
+		attributes
 	]
 exports.conceptType = (term) -> ['ConceptType', stripAttributes(term)]
 exports.referenceScheme = (term) -> ['ReferenceScheme', stripAttributes(term)]


### PR DESCRIPTION
This means that any users do not have to handle this themselves and can just take the LF as-is